### PR TITLE
Add functionality to show/hide cursor

### DIFF
--- a/matchbox/core/mb-window-manager.c
+++ b/matchbox/core/mb-window-manager.c
@@ -53,6 +53,7 @@
 
 #ifdef HAVE_XFIXES
 #include <X11/extensions/Xfixes.h> /* Used to hide the cursor */
+#include <X11/cursorfont.h>
 #endif
 
 #define FALLBACK_THEME_PATH "/usr/share/themes/default"
@@ -1861,7 +1862,8 @@ mb_window_manager_init (MBWMObject *this, va_list vap)
 
   /* set the cursor invisible */
 #if HAVE_XFIXES
-  XFixesHideCursor (wm->xdpy, wm->root_win->xwindow);
+  Cursor curs = XCreateFontCursor (wm->xdpy, XC_left_ptr);
+  XDefineCursor (wm->xdpy, wm->root_win->xwindow, curs);
 #else
   {
     Pixmap pix = XCreatePixmap (wm->xdpy, wm->root_win->xwindow, 1, 1, 1);
@@ -1874,6 +1876,8 @@ mb_window_manager_init (MBWMObject *this, va_list vap)
     XDefineCursor(wm->xdpy, wm->root_win->xwindow, blank_curs);
   }
 #endif
+  wm_set_cursor_visibility(wm, FALSE);
+
   return 1;
 }
 
@@ -2436,4 +2440,26 @@ mb_adjust_dialog_title_position (MBWindowManager *wm,
   mb_wm_object_signal_emit (MB_WM_OBJECT (wm),
                             MBWindowManagerSignalThemeChange);
 
+}
+
+void
+wm_set_cursor_visibility(MBWindowManager *wm, Bool visible)
+{
+  if (!(wm->flags & MBWindowManagerFlagCursorVisible) == !visible)
+    return;
+
+  if (visible)
+    {
+#if HAVE_XFIXES
+      XFixesShowCursor (wm->xdpy, wm->root_win->xwindow);
+#endif
+      wm->flags |= MBWindowManagerFlagCursorVisible;
+    }
+  else
+    {
+#if HAVE_XFIXES
+      XFixesHideCursor (wm->xdpy, wm->root_win->xwindow);
+#endif
+      wm->flags &= ~MBWindowManagerFlagCursorVisible;
+    }
 }

--- a/matchbox/core/mb-window-manager.h
+++ b/matchbox/core/mb-window-manager.h
@@ -62,6 +62,7 @@ typedef enum MBWindowManagerFlag
   MBWindowManagerFlagDesktop           = (1<<0),
   MBWindowManagerFlagAlwaysReloadTheme = (1<<1),
   MBWindowManagerFlagLayoutRotated     = (1<<2),
+  MBWindowManagerFlagCursorVisible     = (1<<3),
 } MBWindowManagerFlag;
 
 /* signals must be 2^n, as multiple signals can be sent from one call */
@@ -252,5 +253,8 @@ mb_wm_setup_redirection (MBWindowManager *wm, int redirection);
 
 Time
 mb_wm_get_server_time (MBWindowManager *wm);
+
+void
+wm_set_cursor_visibility(MBWindowManager *wm, Bool visible);
 
 #endif


### PR DESCRIPTION
This is needed if we want to hide/show cursor when external mouse is
connected/disconnected.

So far the functionality is alive only if we have XFixes extension

Signed-off-by: Ivaylo Dimitrov <ivo.g.dimitrov.75@gmail.com>