### PR TITLE
Set sane defaults when there are no WM_HINTS set

### DIFF
--- a/matchbox/core/mb-wm-client-window.c
+++ b/matchbox/core/mb-wm-client-window.c
@@ -813,6 +813,11 @@ mb_wm_client_window_sync_properties ( MBWMClientWindow *win,
 	      win->want_key_input = wmhints->input;
 	      MBWM_DBG("Want key input: %s", wmhints->input ? "yes" : "no" );
 	    }
+	  else
+	    {
+	      MBWM_DBG("No InputHint flag, assuming want key input.");
+	      win->want_key_input = True;
+	    }
 
 	  if (wmhints->flags & StateHint)
 	    {
@@ -844,6 +849,14 @@ mb_wm_client_window_sync_properties ( MBWMClientWindow *win,
 
 	  /* FIXME: should track better if thus has changed or not */
 	  changes |= MBWM_WINDOW_PROP_WM_HINTS;
+	}
+      else
+        {
+          /* Initialize some sane defaults */
+          MBWM_DBG("@@@ New Window no WM Hints set, init with defaults @@@");
+
+	  win->want_key_input = True;
+	  MBWM_DBG("Want key input: yes");
 	}
     }
 


### PR DESCRIPTION
Assume applications which do not set WM_HINTS or do not provide InputHint
to want keyboard input.


Signed-off-by: Ivaylo Dimitrov <ivo.g.dimitrov.75@gmail.com>