### PR TITLE
Drop support for _MOTIF_WM_HINTS

### DIFF
--- a/matchbox/core/mb-wm-client-window.c
+++ b/matchbox/core/mb-wm-client-window.c
@@ -847,7 +847,8 @@ mb_wm_client_window_sync_properties ( MBWMClientWindow *win,
 
 	  if (mwmhints->flags & MWM_HINTS_DECORATIONS)
 	    {
-	      if (mwmhints->decorations == 0)
+	      if (mwmhints->decorations == 0 &&
+			  win->net_type != wm->atoms[MBWM_ATOM_NET_WM_WINDOW_TYPE_NORMAL])
 		{
 		  win->undecorated = TRUE;
 		}


### PR DESCRIPTION
This atom was only used for its decorations prop. The
decorations prop is inted to tell the wm that a window
wants to draw its decorations client side and is used
in this capacity by gtk3 gnome applications as well as
things like xamp. However its usage in hildon can really
only be undesireable as it causes matchbox to size the
applicaiton to be fullscreen while still drawing the hildon
bar above the application. Except for dialogs where the
property is used to for windows that legitimately don't need
decoration like HIM.