### PR TITLE
Fix type CARD32->long

### DIFF
--- a/matchbox/core/mb-window-manager.c
+++ b/matchbox/core/mb-window-manager.c
@@ -1601,7 +1601,7 @@ mb_wm_get_desktop_geometry (MBWindowManager *wm, MBGeometry * geom)
 void
 mb_wm_update_workarea (MBWindowManager *wm, const MBGeometry *geo)
 {
-  static CARD32 val[4];
+  static long val[4];
 
   if (val[0] == geo->x && val[1] == geo->y
       && val[2] == geo->width && val[3] == geo->height)
@@ -1623,7 +1623,7 @@ mb_wm_update_root_win_rectangles (MBWindowManager *wm)
   Display * dpy = wm->xdpy;
   Window    root = wm->root_win->xwindow;
   MBGeometry d_geom;
-  CARD32 val[2];
+  long val[2];
 
   mb_wm_get_desktop_geometry (wm, &d_geom);
   mb_wm_update_workarea (wm, &d_geom);
@@ -2034,7 +2034,7 @@ mb_wm_activate_client_real (MBWindowManager * wm, MBWindowManagerClient *c)
 
   if (is_desktop != was_desktop)
     {
-      CARD32 card = is_desktop ? 1 : 0;
+      long card = is_desktop ? 1 : 0;
 
       XChangeProperty(wm->xdpy, wm->root_win->xwindow,
 		      wm->atoms[MBWM_ATOM_NET_SHOWING_DESKTOP],
@@ -2371,7 +2371,7 @@ mb_wm_get_modality_type (MBWindowManager * wm)
 static void
 mb_wm_set_n_desktops (MBWindowManager *wm, int n_desktops)
 {
-  CARD32 card32 = n_desktops;
+  long card32 = n_desktops;
 
   wm->n_desktops = n_desktops;
 
@@ -2387,7 +2387,7 @@ mb_wm_set_n_desktops (MBWindowManager *wm, int n_desktops)
 void __attribute__ ((visibility("hidden")))
 mb_wm_select_desktop (MBWindowManager *wm, int desktop)
 {
-  CARD32                 card32 = desktop;
+  long                 card32 = desktop;
   MBWindowManagerClient *c;
   int                    old_desktop;
 

--- a/matchbox/core/mb-wm-client-base.c
+++ b/matchbox/core/mb-wm-client-base.c
@@ -382,7 +382,7 @@ mb_wm_client_base_set_state_props (MBWindowManagerClient *c)
   Window            xwin  = c->window->xwindow;
   MBWindowManager  *wm    = c->wmref;
   Display          *xdpy  = wm->xdpy;
-  CARD32            card32[2];
+  long            card32[2];
   Atom              ewmh_state [MBWMClientWindowEWHMStatesCount];
   int               ewmh_i = 0;
 
@@ -625,7 +625,7 @@ mb_wm_client_base_display_sync (MBWindowManagerClient *client)
   if (mb_wm_client_is_mapped (client) && mb_wm_client_needs_geometry_sync (client))
     {
       int x, y, w, h;
-      CARD32 wgeom[4];
+      long wgeom[4];
 
       mb_wm_util_async_trap_x_errors(wm->xdpy);
 

--- a/matchbox/core/mb-wm-root-window.c
+++ b/matchbox/core/mb-wm-root-window.c
@@ -190,7 +190,7 @@ mb_wm_root_window_update_supported_props (MBWMRootWindow *win)
 {
   MBWindowManager  *wm = win->wm;
   Window            rwin = win->xwindow;
-  CARD32            num_supported = 0;
+  long            num_supported = 0;
 
   /*
    * Supported info
@@ -272,7 +272,7 @@ mb_wm_root_window_init_properties (MBWMRootWindow * win)
   Window            rwin = win->xwindow;
   Window            hwin = win->hidden_window;
 
-  CARD32            card32;
+  long            card32;
   unsigned long     val[2];
   char             *app_name = "matchbox";
   pid_t             pid;


### PR DESCRIPTION
Use long instead of CARD32 for XChangeProperty calls.
XChangeProperty expects long, but CARD32 is int on 64 Bit

This fixes maemo-leste/bugtracker#607

Please note, that hildon-desktop is statically compiled against libmatchbox2 (why?), so must be recompiled.